### PR TITLE
chore: migrate to @agentic-dev-library npm organization

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -3,7 +3,7 @@ description: 'AI agent fleet management, sandboxed execution, and orchestration 
 author: 'Jon Bogaty'
 branding:
   icon: 'cpu'
-  color: 'blue'
+  color: 'purple'
 
 inputs:
   command:
@@ -19,7 +19,7 @@ inputs:
     description: 'GitHub token for API access'
     required: false
   version:
-    description: 'agentic-control version to use'
+    description: '@agentic-dev-library/control version to use'
     required: false
     default: 'latest'
 
@@ -35,13 +35,13 @@ runs:
   using: 'composite'
   steps:
     - name: Setup Node.js
-      uses: actions/setup-node@v6
+      uses: actions/setup-node@395ad3262231945c25e8478fd5baf05154b1d79f # v6.1.0
       with:
         node-version: '22'
 
-    - name: Install agentic-control
+    - name: Install @agentic-dev-library/control
       shell: bash
-      run: npm install -g agentic-control@${{ inputs.version }}
+      run: npm install -g @agentic-dev-library/control@${{ inputs.version }}
 
     - name: Run command
       id: run
@@ -49,36 +49,43 @@ runs:
       env:
         GH_TOKEN: ${{ inputs.github_token }}
         GITHUB_TOKEN: ${{ inputs.github_token }}
+        INPUT_COMMAND: ${{ inputs.command }}
+        INPUT_ARGS: ${{ inputs.args }}
+        INPUT_CONFIG: ${{ inputs.config }}
       run: |
-        # Build command
-        CMD="npx agentic-control ${{ inputs.command }}"
+        # Build command array safely to prevent command injection
+        declare -a CMD_ARGS
+        CMD_ARGS+=("$INPUT_COMMAND")
 
-        if [ -n "${{ inputs.args }}" ]; then
-          CMD="$CMD ${{ inputs.args }}"
+        if [ -n "$INPUT_ARGS" ]; then
+          read -r -a EXTRA_ARGS <<< "$INPUT_ARGS"
+          CMD_ARGS+=("${EXTRA_ARGS[@]}")
         fi
 
-        if [ -n "${{ inputs.config }}" ]; then
-          CMD="$CMD --config ${{ inputs.config }}"
+        if [ -n "$INPUT_CONFIG" ]; then
+          CMD_ARGS+=("--config" "$INPUT_CONFIG")
         fi
 
-        echo "Running: $CMD"
+        echo "Running: agentic ${CMD_ARGS[*]}"
 
         # Run and capture output
         set +e
-        OUTPUT=$($CMD 2>&1)
+        OUTPUT=$(npx @agentic-dev-library/control "${CMD_ARGS[@]}" 2>&1)
         EXIT_CODE=$?
         set -e
 
         echo "$OUTPUT"
 
-        # Set outputs
-        echo "result<<EOF" >> $GITHUB_OUTPUT
-        echo "$OUTPUT" >> $GITHUB_OUTPUT
-        echo "EOF" >> $GITHUB_OUTPUT
+        # Set outputs using heredoc for multi-line safety
+        {
+          echo "result<<EOF"
+          echo "$OUTPUT"
+          echo "EOF"
+        } >> "$GITHUB_OUTPUT"
 
         if [ $EXIT_CODE -eq 0 ]; then
-          echo "status=success" >> $GITHUB_OUTPUT
+          echo "status=success" >> "$GITHUB_OUTPUT"
         else
-          echo "status=failure" >> $GITHUB_OUTPUT
+          echo "status=failure" >> "$GITHUB_OUTPUT"
           exit $EXIT_CODE
         fi

--- a/actions/agentic-ci-resolution/action.yml
+++ b/actions/agentic-ci-resolution/action.yml
@@ -52,5 +52,5 @@ runs:
           REPO="$GITHUB_REPOSITORY"
         fi
         
-        # Use exact pinned version of agentic-control to prevent supply chain attacks (CWE-829)
-        npx agentic-control@1.1.0 triage fix "$PR_NUM" --repo "$REPO" --iterations "${{ inputs.iterations }}"
+        # Use exact pinned version of @agentic-dev-library/control to prevent supply chain attacks (CWE-829)
+        npx @agentic-dev-library/control@1.2.0 triage fix "$PR_NUM" --repo "$REPO" --iterations "${{ inputs.iterations }}"

--- a/actions/agentic-issue-triage/action.yml
+++ b/actions/agentic-issue-triage/action.yml
@@ -1,6 +1,9 @@
 name: 'Agentic Issue Triage'
 description: 'Triage a GitHub issue using an AI agent.'
-author: 'jbcom/agentic-control'
+author: 'agentic-dev-library'
+branding:
+  icon: 'alert-circle'
+  color: 'orange'
 
 inputs:
   github_token:
@@ -10,7 +13,7 @@ inputs:
     description: 'The number of the issue to triage.'
     required: true
   model:
-    description: 'The Ollama model to use for the triage.'
+    description: 'The AI model to use for the triage.'
     required: false
     default: 'llama3'
   api_key:
@@ -25,25 +28,23 @@ outputs:
   assignee:
     description: 'The assignee suggested by the agent.'
 
-branding:
-  icon: 'alert-circle'
-  color: 'orange'
-
 runs:
   using: 'composite'
   steps:
-    - name: 'Checkout code'
-      uses: actions/checkout@v4
-
-    - name: 'Install dependencies'
-      shell: bash
-      run: pnpm install --frozen-lockfile
+    - name: Setup Node.js
+      uses: actions/setup-node@395ad3262231945c25e8478fd5baf05154b1d79f # v6.1.0
+      with:
+        node-version: '22'
 
     - name: 'Run issue triage'
       shell: bash
+      env:
+        GH_TOKEN: ${{ inputs.github_token }}
+        GITHUB_TOKEN: ${{ inputs.github_token }}
+        INPUT_ISSUE_NUMBER: ${{ inputs.issue_number }}
+        INPUT_MODEL: ${{ inputs.model }}
+        INPUT_API_KEY: ${{ inputs.api_key }}
       run: |
-        pnpm exec agentic-control issue-triage \
-          --issue-number "${{ inputs.issue_number }}" \
-          --model "${{ inputs.model }}" \
-          --api-key "${{ inputs.api_key }}" \
-          --github-token "${{ inputs.github_token }}"
+        # Use exact pinned version of @agentic-dev-library/control to prevent supply chain attacks (CWE-829)
+        npx @agentic-dev-library/control@1.2.0 triage assess "$INPUT_ISSUE_NUMBER" \
+          --model "$INPUT_MODEL"

--- a/actions/agentic-orchestrator/action.yml
+++ b/actions/agentic-orchestrator/action.yml
@@ -33,8 +33,8 @@ runs:
         ORCH_CMD: ${{ inputs.command }}
         ORCH_ARGS: ${{ inputs.args }}
       run: |
-        # Use exact pinned version of agentic-control to prevent supply chain attacks (CWE-829)
+        # Use exact pinned version of @agentic-dev-library/control to prevent supply chain attacks (CWE-829)
         # and use environment variables for safe argument passing.
         # Note: We split ORCH_ARGS into an array to avoid command injection while allowing multiple flags.
         read -r -a ARGS_ARRAY <<< "$ORCH_ARGS"
-        npx agentic-control@1.1.0 fleet "$ORCH_CMD" "${ARGS_ARRAY[@]}"
+        npx @agentic-dev-library/control@1.2.0 fleet "$ORCH_CMD" "${ARGS_ARRAY[@]}"

--- a/actions/agentic-pr-review/action.yml
+++ b/actions/agentic-pr-review/action.yml
@@ -49,6 +49,6 @@ runs:
           ARGS+=("--head" "$INPUT_HEAD")
         fi
         
-        # Use exact pinned version of agentic-control to prevent supply chain attacks (CWE-829)
+        # Use exact pinned version of @agentic-dev-library/control to prevent supply chain attacks (CWE-829)
         # and use array for safe argument passing to prevent command injection
-        npx agentic-control@1.1.0 triage review "${ARGS[@]}"
+        npx @agentic-dev-library/control@1.2.0 triage review "${ARGS[@]}"

--- a/packages/agentic-control/package.json
+++ b/packages/agentic-control/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "agentic-control",
-  "version": "1.1.0",
+  "name": "@agentic-dev-library/control",
+  "version": "1.2.0",
   "description": "Unified AI agent fleet management, triage, and orchestration toolkit for control centers",
   "type": "module",
   "main": "./dist/index.js",
@@ -105,7 +105,7 @@
     "tsx": "4.21.0",
     "typescript": "^5.7.0",
     "vitest": "^4.0.14",
-    "vitest-agentic-control": "workspace:*"
+    "@agentic-dev-library/vitest-control": "workspace:*"
   },
   "engines": {
     "node": ">=22.0.0"
@@ -135,11 +135,14 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/jbdevprimary/agentic-control.git",
+    "url": "https://github.com/agentic-dev-library/control.git",
     "directory": "packages/agentic-control"
   },
-  "homepage": "https://github.com/jbdevprimary/agentic-control#readme",
+  "homepage": "https://agentic-dev-library.github.io/packages/control/",
   "bugs": {
-    "url": "https://github.com/jbdevprimary/agentic-control/issues"
+    "url": "https://github.com/agentic-dev-library/control/issues"
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }

--- a/packages/vitest-agentic-control/package.json
+++ b/packages/vitest-agentic-control/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "vitest-agentic-control",
+  "name": "@agentic-dev-library/vitest-control",
   "version": "1.0.0",
-  "description": "Vitest plugin with fixtures and utilities for agentic-control E2E testing",
+  "description": "Vitest plugin with fixtures and utilities for @agentic-dev-library/control E2E testing",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
@@ -64,7 +64,8 @@
     "vitest",
     "testing",
     "fixtures",
-    "agentic-control",
+    "agentic-dev-library",
+    "control",
     "e2e",
     "mcp",
     "ai-agents",
@@ -74,11 +75,14 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/jbdevprimary/agentic-control.git",
+    "url": "https://github.com/agentic-dev-library/control.git",
     "directory": "packages/vitest-agentic-control"
   },
-  "homepage": "https://github.com/jbdevprimary/agentic-control/tree/main/packages/vitest-agentic-control",
+  "homepage": "https://agentic-dev-library.github.io/packages/control/",
   "bugs": {
-    "url": "https://github.com/jbdevprimary/agentic-control/issues"
+    "url": "https://github.com/agentic-dev-library/control/issues"
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }


### PR DESCRIPTION
## Summary

**BREAKING CHANGE**: Package renamed from `agentic-control` to `@agentic-dev-library/control`

This PR migrates all packages and GitHub Actions to use the new `@agentic-dev-library` npm organization scope.

## Changes

### Package Renames
- `agentic-control` → `@agentic-dev-library/control`
- `vitest-agentic-control` → `@agentic-dev-library/vitest-control`

### GitHub Actions Updated
- `action.yml` - Root action now uses scoped package
- `actions/agentic-pr-review` - Updated to `@agentic-dev-library/control@1.2.0`
- `actions/agentic-orchestrator` - Updated to `@agentic-dev-library/control@1.2.0`
- `actions/agentic-ci-resolution` - Updated to `@agentic-dev-library/control@1.2.0`
- `actions/agentic-issue-triage` - Updated to `@agentic-dev-library/control@1.2.0`

### Repository URLs
- Updated all repository URLs to point to `agentic-dev-library` org
- Homepage now points to centralized docs site: https://agentic-dev-library.github.io/packages/control/

## Migration Guide

Update package.json:

```diff
- "agentic-control": "^1.1.0"
+ "@agentic-dev-library/control": "^1.2.0"
```

Update imports:

```diff
- import { Fleet } from 'agentic-control';
+ import { Fleet } from '@agentic-dev-library/control';
```

## Checklist

- [x] Package names updated to @agentic-dev-library scope
- [x] All GitHub Actions updated
- [x] Repository URLs corrected
- [x] publishConfig added for public access
- [ ] Publish to npm under new name after merge
- [ ] Deprecate old `agentic-control` package on npm

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **BREAKING**: Rename to scoped packages and update all actions to use `@agentic-dev-library/control@1.2.0`.
> 
> - Rename `agentic-control` → `@agentic-dev-library/control` (v1.2.0) and `vitest-agentic-control` → `@agentic-dev-library/vitest-control`; update devDependency reference
> - Update composite actions (`action.yml`, `agentic-pr-review`, `agentic-orchestrator`, `agentic-ci-resolution`, `agentic-issue-triage`) to use `npx @agentic-dev-library/control@1.2.0` and pin `actions/setup-node` by SHA
> - Improve script safety: build command args via arrays, pass inputs via env vars, and use heredoc for multi-line outputs
> - Refresh metadata: branding tweaks, repository/homepage/bugs URLs moved to `agentic-dev-library`, add `publishConfig: public`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 365ca2a81bca19f32b4e10c68c1ba4c3de8783bc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->