### PR TITLE
fix(cd): use CI_GITHUB_TOKEN directly for semantic-release

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -96,7 +96,8 @@ jobs:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
         with:
           fetch-depth: 0
-          persist-credentials: false
+          token: ${{ secrets.CI_GITHUB_TOKEN }}
+          persist-credentials: true
 
       - uses: actions/setup-node@395ad3262231945c25e8478fd5baf05154b1d79f # v6.1.0
         with:
@@ -116,8 +117,8 @@ jobs:
       - name: Semantic Release
         env:
           # CI_GITHUB_TOKEN is a PAT that can bypass branch protection for release commits
-          GITHUB_TOKEN: ${{ secrets.CI_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
-          GH_TOKEN: ${{ secrets.CI_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.CI_GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.CI_GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           NPM_CONFIG_PROVENANCE: 'true'
@@ -141,7 +142,7 @@ jobs:
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
-          password: ${{ secrets.CI_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Extract metadata
         id: meta


### PR DESCRIPTION
Uses CI_GITHUB_TOKEN directly for semantic-release to enable pushing to protected branches

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Standardizes auth tokens in `cd.yml` for releases.
> 
> - `release` job checkout now uses `token: ${{ secrets.CI_GITHUB_TOKEN }}` with `persist-credentials: true`
> - `semantic-release` env `GITHUB_TOKEN`/`GH_TOKEN` set to `secrets.CI_GITHUB_TOKEN` (fallbacks removed)
> - Docker registry login now uses `secrets.GITHUB_TOKEN` for `password` (fallback removed)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0c4bb84ebd610cdaa0be342dca78964e944b789c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->