### PR TITLE
fix(ci): correct artifact paths for monorepo structure

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,7 +58,7 @@ jobs:
         uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
         with:
           name: build-output
-          path: dist
+          path: packages/**/dist
           retention-days: 1
 
   test:
@@ -80,7 +80,7 @@ jobs:
       - uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
         with:
           name: build-output
-          path: dist
+          path: packages
 
       - name: Run tests with coverage
         run: pnpm run test:coverage
@@ -125,7 +125,7 @@ jobs:
       - uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
         with:
           name: build-output
-          path: dist
+          path: packages
 
       - name: Git config
         run: |


### PR DESCRIPTION
## Summary

Fix CI failure by correcting artifact upload/download paths for the monorepo structure.

### Changes
- Upload path: `dist` → `packages/**/dist` (capture all package builds)
- Download path: `dist` → `packages` (restore correct directory structure)

### Source
This fix was identified by **Jules AI** (session `13997878939372578345`) but the session completed without creating a PR. The patch was manually extracted and applied.

### Related
- Fixes CI failure in PR #46
- Jules session: https://jules.google.com/session/13997878939372578345

---
<sub>🤖 Changes identified by Jules AI, PR created by control-center</sub>